### PR TITLE
Fix nil error when accessing Wardrobe outfits menu (#55)

### DIFF
--- a/Core/Preview.lua
+++ b/Core/Preview.lua
@@ -401,7 +401,7 @@ local function loadInitialize(self, level)
 			end
 		end
 		if UIDROPDOWNMENU_MENU_VALUE == "outfits" then
-			if #C_TransmogCollection.GetOutfits() > 0 then
+			if C_TransmogCollection.GetOutfits and #C_TransmogCollection.GetOutfits() > 0 then
 				for i, outfit in ipairs(C_TransmogCollection.GetOutfits()) do
 					local info = UIDropDownMenu_CreateInfo()
 					info.text = C_TransmogCollection.GetOutfitInfo(outfit)


### PR DESCRIPTION
Hi,

Added guard check for C_TransmogCollection.GetOutfits before calling it. The function may not be available depending on game state, causing "attempt to call field 'GetOutfits' (a nil value)" error when opening the Load menu's Wardrobe outfits submenu.

Full transparency - I used Claude Code to review and create this, but I have verified the error and fix in game. 