### PR TITLE
Fix Options button opening wrong settings panel

### DIFF
--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -834,7 +834,7 @@ mog.menu.preview:SetPoint("LEFT", mog.menu.catalogue, "RIGHT", 5, 0);
 
 --// Options Menu
 function mog:ToggleOptions()
-	Settings.OpenToCategory(MogIt);
+	Settings.OpenToCategory(mog.settingsCategoryID);
 end
 
 mog.menu.options = mog.menu:CreateMenu(L["Options"]);

--- a/Core/Options.lua
+++ b/Core/Options.lua
@@ -2,9 +2,6 @@ local MogIt,mog = ...;
 local L = mog.L;
 
 function mog.createOptions()
-	local frame = CreateFrame("Frame");
-	Settings.RegisterCanvasLayoutCategory(frame, MogIt);
-
 	local config = LibStub("AceConfig-3.0");
 	local dialog = LibStub("AceConfigDialog-3.0");
 	local db = LibStub("AceDBOptions-3.0");
@@ -216,6 +213,7 @@ function mog.createOptions()
 	};
 	config:RegisterOptionsTable("MogIt",options.args.general);
 	dialog:AddToBlizOptions("MogIt");
+	mog.settingsCategoryID = dialog.BlizOptionsIDMap["MogIt"];
 
 	options.args.tooltip = {
 		type = "group",


### PR DESCRIPTION
The Options button was not opening the MogIt addon settings because Settings.OpenToCategory requires the numeric category ID created by AceConfigDialog, not the addon name string.

- Remove unused empty frame creation in Options.lua
- Store the category ID from AceConfigDialog.BlizOptionsIDMap after AddToBlizOptions is called
- Use the stored category ID in ToggleOptions