### PR TITLE
Remove broken transmog detection from Equip current gear

### DIFF
--- a/Core/Preview.lua
+++ b/Core/Preview.lua
@@ -247,19 +247,6 @@ local previewMenu = {
 				local slotID = GetInventorySlotInfo(k);
 				local item = GetInventoryItemLink("player", slotID);
 				if item then
-					local transmogLocation = TransmogUtil.GetTransmogLocation(slotID, Enum.TransmogType.Appearance, Enum.TransmogModification.Main);
-					local isTransmogrified, _, _, _, _, _, isHideVisual, texture = C_Transmog.GetSlotInfo(transmogLocation);
-					local baseSourceID, baseVisualID, appliedSourceID, appliedVisualID = C_Transmog.GetSlotVisualInfo(transmogLocation);
-					if isTransmogrified then
-						if isHideVisual then
-							item = nil;
-						else
-							local categoryID, appearanceVisualID, canEnchant, icon, isCollected, link = C_TransmogCollection.GetAppearanceSourceInfo(appliedSourceID);
-							item = link;
-						end
-					end
-				end
-				if item then
 					mog.view.AddItem(item, currentPreview);
 				end
 			end


### PR DESCRIPTION
The C_Transmog.GetSlotInfo API is not available, causing errors. The related APIs also don't return applied transmog data, so the feature cannot work. Simplified to just load base equipped items.